### PR TITLE
質問内容に改行が反映されるようにコードを追加、（結果HTMLを完全エスケープしない状態に変更）

### DIFF
--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @questions.each do |question| %>
   <h2><%= question.title %></h2>
-  <p><%= question.content %></p>
+  <p><%= simple_format(question.content) %></p>
   <p><%= question.user.name %></p>
   <p>更新日時 :<%= date_japan(question.updated_at) %></p>
   <hr>


### PR DESCRIPTION
#56 
seedデータのHTMLデータの表示をどうするかのissueと同時に解決できそうかなと思ったのでこちらにまとめます。

質問内容の出力を`<p><%= simple_format(question.content) %></p>`
のようにsimple_formatを使うことで、HTMLを通常表示で表示させています。
また、質問内容を書くときに入れた改行が表示に反映されました。

完全にエスケープはされてないですが、scriptタグははじいてくれるようなので
使用してもOKでしょうか？

参考このあたりです。
http://railsdoc.com/references/simple_format
http://qiita.com/kamesennin/items/8b01e86491297347394b

ただ、気持ち悪いことに質問内容の前後に空のpタグが入ります。。