### PR TITLE
Add link to question-index(root), question-new, Move ranking to the left on a navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,11 +20,15 @@
           <%= link_to "stack overflow Dive-23-10", root_path, class: "navbar-brand" %>
         </div>
         <div class="collapse navbar-collapse" id="sp-nav">
+          <ul class="nav navbar-nav navbar-left">
+            <li><%= link_to "質問一覧", root_path %></li>
+            <li><%= link_to 'ランキング', ranking_index_path %></li>
+          </ul>
           <ul class="nav navbar-nav navbar-right">
             <% if user_signed_in? %>
               <li><%= link_to current_user.name + "さん", edit_user_registration_path %></li>
+              <li><%= link_to "＋質問する", new_question_path %></li>
               <li><%= link_to 'お気に入り', favorites_index_path %></li>
-              <li><%= link_to 'ランキング', ranking_index_path %></li>
               <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
             <% else %>
               <li><%= link_to 'ログイン', new_user_session_path  %></li>


### PR DESCRIPTION
#57 

・質問入力画面へのリンクがなくて不便だったので追加しました。
・ついでに質問一覧画面へのリンクを明示的にいれました（ロゴもroot_pathへのリンクではあるのですが。）
・こちらもついでですが、ランキングの場所を左に移動して、ログインしていない状態でもリンクが出るようにしました（こちらはユーザーに紐づいていないと思うので。）

なにかあればご指摘ください！
（デザインfixではないので、このあとのデザイン検討の段階で変えてもよいかなと思います）

参考画面
![5](https://cloud.githubusercontent.com/assets/14960981/26486194/08cef898-4235-11e7-8494-8742a3dbda01.png)
