### PR TITLE
ナビゲーションに「ユーザー（ユーザー一覧画面へのリンク）」を追加、ログアウト時のユーザー一覧画面へのアクセスのため修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
   def index
-    @users_except_current_user = User.all_except(current_user)
+    if user_signed_in?
+      @users = User.all_except(current_user)
+    else
+      @users = User.all
+    end
   end
 
   def show

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
           <ul class="nav navbar-nav navbar-left">
             <li><%= link_to "質問一覧", root_path %></li>
             <li><%= link_to 'ランキング', ranking_index_path %></li>
+            <li><%= link_to 'ユーザー', users_path %></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <% if user_signed_in? %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,10 +1,10 @@
 <h1>ユーザー一覧</h1>
 
-<% @users_except_current_user.each do |user| %>
-<div class="user_info">
-  <h2><%= user.name %></h2>
-  <p>profile: <%= user.profile %></p>
-  <p>avatar: <%= user.avatar %></p>
-  <p>vote: </p>
-</div>
+<% @users.each do |user| %>
+  <div class="user_info">
+    <h2><%= user.name %></h2>
+    <p>profile: <%= user.profile %></p>
+    <p>avatar: <%= user.avatar %></p>
+    <p>vote: </p>
+  </div>
 <% end %>


### PR DESCRIPTION
#92 

一応プルリクしていますが、独断でやっている部分があるためご確認・検討をお願いいたします。

1. ナビゲーションにユーザー一覧画面へのリンクを追加しました。
2. ログアウト時にもユーザー一覧画面にアクセスするとcurrent_userがないということでエラーになったため、コントローラーにログアウト時の振り分けを追加しました。

上記の２こめについて、書き方と、そもそもログアウト時にはユーザー一覧画面を見られなくてよいかもしれないので、ご意見お聞かせください。
