### PR TITLE
回答フォーム、コンテンツ表示でマークダウンが使えるように修正

### DIFF
--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -1,6 +1,3 @@
-
-
-
 <%= simple_form_for([question,answer]) do |f| %>
   <%= f.hidden_field :question_id %>
   <div>

--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -1,7 +1,10 @@
-<%= form_for([question,answer]) do |f| %>
+
+
+
+<%= simple_form_for([question,answer]) do |f| %>
   <%= f.hidden_field :question_id %>
   <div>
-    <%= f.text_area :content, placeholder: "内容" %>
+    <%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10 },label: "回答を入力" %>
   </div>
   <div>
     <%= f.submit '回答する' %>

--- a/app/views/answers/_index.html.erb
+++ b/app/views/answers/_index.html.erb
@@ -1,10 +1,9 @@
 <% answers.each do |answer| %>
   <% unless answer.id.nil? %>
     <div>
-      回答者：<%= answer.user.name %>
+      <%= markdown(answer.content).html_safe %>
     </div>
-    <div>
-      <%= simple_format(answer.content) %>
-    </div>
+    <p>回答者：<%= answer.user.name %></p>
+    <hr>
   <% end %>
 <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -17,6 +17,6 @@
  /
  <%= link_to "戻る", :back %>
 
- <p>回答一覧</p>
+ <h3>回答一覧</h3>
  <%= render partial: 'answers/index', locals: { answers: @answers, question: @question } %>
  <%= render partial: 'answers/form', locals: { answer: @answer, question: @question } %>


### PR DESCRIPTION
#94 
・質問詳細などを参考に回答部分でもマークダウンを使えるように修正
・回答一覧　の文字がわかりにくくなっていたので、とりあえずh3タグに変更
・回答者の表示場所を質問に倣って内容の下に配置