### PR TITLE
ユーザー詳細画面のエラー表示を修正、ログアウト時に画面を見られるように修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,4 +54,10 @@ module ApplicationHelper
       markdown = Redcarpet::Markdown.new(html_render, options)
       markdown.render(text)
   end
+  # 引数でわたされたデータが空かどうかを判定する
+  def is_blank?(content)
+    if content.blank?
+      true
+    end
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,12 @@
 module UsersHelper
+
+  # ログインしているユーザーのユーザー詳細画面かどうかを判定する
+  def is_current_user?(comparison_user)
+    if user_signed_in?
+      if current_user.id == comparison_user.id
+        true
+      end
+    end
+  end
+
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,4 @@
 module UsersHelper
-
   # ログインしているユーザーのユーザー詳細画面かどうかを判定する
   def is_current_user?(comparison_user)
     if user_signed_in?
@@ -8,5 +7,4 @@ module UsersHelper
       end
     end
   end
-
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <% if user_signed_in? %>
-              <li><%= link_to current_user.name + "さん", edit_user_registration_path %></li>
+              <li><%= link_to current_user.name + "さん", user_path(current_user) %></li>
               <li><%= link_to "＋質問する", new_question_path %></li>
               <li><%= link_to 'お気に入り', favorites_index_path %></li>
               <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @users.each do |user| %>
   <div class="user_info">
-    <h2><%= user.name %></h2>
+    <h2><%= link_to user.name, user_path(user) %></h2>
     <p>profile: <%= user.profile %></p>
     <p>avatar: <%= user.avatar %></p>
     <p>vote: </p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,9 @@
 <%= profile_img(@user) %><br>
 名前：<%= @user.name %><br>
 プロフィール：<%= @user.profile %>
-<%= "#{@user.name}さんの自己紹介は未記入です。" if @user.profile.blank? %><br>
+<% if is_blank?(@user.profile) %>
+  <%= "#{@user.name}さんの自己紹介は未記入です。"  %><br>
+<% end %>
 e-mail：<%= @user.email %><br>
 質問数 <%= @questions.count %>回<br>
 回答数 <%= @answers.count %>回<br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,7 +20,7 @@ e-mail：<%= @user.email %><br>
 <%= "#{@user.name}さんの質問はありません。" if @questions.empty? %>
 <% @questions.each do |question| %>
   <%= link_to question.title, question_path(question.id) %><br>
-  <%= question.votes.length %>票<br>
+  <%= question.votes.count %>票<br>
   <%= question.created_at %><hr>
 <% end %>
 
@@ -28,6 +28,6 @@ e-mail：<%= @user.email %><br>
 <%= "#{@user.name}さんの回答はありません。" if @questions.empty? %>
 <% @answers.each do |answer| %>
   <%= link_to answer.question.title, question_answer_path(answer.question.id, answer.id) %><br>
-  <%= answer.votes.length %>票<br>
+  <%= answer.votes.count %>票<br>
   <%= answer.created_at %><hr>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,30 +1,33 @@
-<% if current_user.id == @user.id %>
+<% if is_current_user?(@user) %>
   <h1>マイページ</h1>
 <% else %>
   <h1><%= @user.name %>さんの詳細</h1>
 <% end %>
 
 <%= profile_img(@user) %><br>
-  名前：<%= @user.name %><br>
-  プロフィール：<%= @user.profile %>
-<%= "#{@user.name}さんの自己紹介は未記入です。" if @user.profile.empty? %><br>
-  e-mail：<%= @user.email %><br>
-  質問数 <%= @questions.count %>回<br>
-  回答数 <%= @answers.count %>回<br>
-<%= link_to "編集", edit_user_registration_path, class: 'btn btn-default btn-sm btn-success' %>
+名前：<%= @user.name %><br>
+プロフィール：<%= @user.profile %>
+<%= "#{@user.name}さんの自己紹介は未記入です。" if @user.profile.blank? %><br>
+e-mail：<%= @user.email %><br>
+質問数 <%= @questions.count %>回<br>
+回答数 <%= @answers.count %>回<br>
+
+<% if is_current_user?(@user) %>
+  <%= link_to "編集", edit_user_registration_path, class: 'btn btn-default btn-sm btn-success' %>
+<% end %>
 
 <h2>投稿した質問</h2>
 <%= "#{@user.name}さんの質問はありません。" if @questions.empty? %>
 <% @questions.each do |question| %>
   <%= link_to question.title, question_path(question.id) %><br>
-  <%= question.vote.to_i %>票<br>
+  <%= question.votes.length %>票<br>
   <%= question.created_at %><hr>
 <% end %>
 
 <h2>投稿した回答</h2>
 <%= "#{@user.name}さんの回答はありません。" if @questions.empty? %>
 <% @answers.each do |answer| %>
- <%= link_to answer.question.title, question_answer_path(answer.question.id, answer.id) %><br>
- <%= answer.vote.to_i %>票<br>
- <%= answer.created_at %><hr>
+  <%= link_to answer.question.title, question_answer_path(answer.question.id, answer.id) %><br>
+  <%= answer.votes.length %>票<br>
+  <%= answer.created_at %><hr>
 <% end %>


### PR DESCRIPTION
#96 

＜ユーザー詳細画面修正＞
・ユーザー詳細画面のエラー表示を修正（vote.to_i　部分にエラーがでていたので votes.count　に修正）
・ログアウト時にユーザー詳細を見られるように、判定にsign_inを追加して、ヘルパーに格納（※記述場所等自信がないのでご指摘ください）
・編集ボタンをカレントユーザーのページのみに表示するように修正

＜ユーザー一覧画面修正＞
・ユーザー詳細画面へのリンクを追加（名前部分）

＜ナビゲーション＞
ユーザーネームのリンク先をマイページに変更（マイページに編集ページへのリンクがあるので）