### PR TITLE
Issues/#46　質問編集、新規投稿フォームのバリデーション追加など

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css
@@ -5,3 +5,17 @@
   To use Glyphicons sprites instead of Font Awesome, replace with "require twitter-bootstrap-static/sprites"
   =require twitter-bootstrap-static/fontawesome
   */
+
+/*railsの対応のnotice,alertの名称に対応するため、クラスを作成 */
+/*もとはalert-success */
+.alert-notice{
+  background-color: #dff0d8;
+  border-color: #d0e9c6;
+  color: #3c763d;
+}
+/*もとはalert-success */
+.alert-alert{
+  background-color: #f2dede;
+  border-color: #ebcccc;
+  color: #a94442;
+}

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -7,8 +7,11 @@ class AnswersController < ApplicationController
   def create
     @answer = current_user.answers.build(answer_params)
     @question = @answer.question
-    @answer.save
-    redirect_to question_path(@question)
+    if @answer.save
+      redirect_to question_path(@question), notice: '回答を投稿しました'
+    else
+      redirect_to question_path(@question)
+    end
   end
 
   def edit

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -17,8 +17,11 @@ class QuestionsController < ApplicationController
       tag = Tag.register!(name)
       @question.taggings.build(tag_id: tag.id)
     end
-    @question.save
-    redirect_to questions_path
+    if @question.save
+      redirect_to questions_path, notice: '質問を投稿しました'
+    else
+      render 'new'
+    end
   end
 
   def edit

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,4 +2,6 @@ class Answer < ActiveRecord::Base
   belongs_to :user
   belongs_to :question
   has_many :votes, dependent: :destroy
+  #バリデーション
+  validates :content, presence: true
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,6 +5,9 @@ class Question < ActiveRecord::Base
   has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
   has_many :votes, dependent: :destroy
+  #バリデーション
+  validates :title, presence: true
+  validates :content, presence: true
 
   def favorite_by(user)
     favorites.find_by(user_id: user.id)

--- a/app/views/application/_display_flash_message.html.erb
+++ b/app/views/application/_display_flash_message.html.erb
@@ -1,0 +1,7 @@
+<% if flash %>
+  <% flash.each do |name, message| %>
+    <div class="alert alert-<%= name %>">
+      <p><%= message %></p>
+    </div>
+  <% end -%>
+<% end %>

--- a/app/views/application/_display_form_error.html.erb
+++ b/app/views/application/_display_form_error.html.erb
@@ -1,0 +1,9 @@
+<% if form_error.errors.any? %>
+  <div class="alert alert-danger">
+    <ul>
+      <% form_error.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>質問を編集する</h1>
-
+<%= render partial: 'application/display_form_error', locals: {form_error: @question} %>
 <%= form_for @question do |f| %>
   <div class="field">
     <%= f.label :title %><br />

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,5 +1,5 @@
 <h1>質問一覧</h1>
-
+<%= render partial: 'application/display_flash_message', locals: {flash: flash} %>
 <% @questions.each do |question| %>
   <h2>
     <%= link_to question_path(question) do %><%= question.title %><% end %>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,5 +1,5 @@
 <h1>新規質問</h1>
-
+<%= render partial: 'application/display_form_error', locals: {form_error: @question} %>
 <%= simple_form_for(@question) do |f| %>
   <div><%= f.text_field :title, placeholder: "タイトル" %></div>
   <%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10 } %>


### PR DESCRIPTION
#46 
#47 

ログイン画面などはまだ対応できていません。

・質問編集、新規投稿フォームのバリデーション追加
・質問編集、新規投稿フォームのsave、update時の成功・失敗振り分け処理を追加
・質問編集、新規質問投稿画面にバリデーション結果のエラーメッセージエリアを追加
・質問一覧画面にflashメッセージエリアを追加
・メッセージ用のCSS追加
※お知らせ&エラーメッセージエリアはパーシャル化しています。

コントローラー周りを編集していますので、コンフリクトする場合はコンフリクトしないファイルだけをプルリクしなおします。（そのために#46ブランチを別に作っています）

※コンフリクトするファイルについてはreviewOK後にコードを共有しますので、
現在編集している人に挿入してもらう感じかなと思っています。

---

以下調べてみてできなかったので、ご助言をいただきたく。

質問詳細にある回答フォームにもバリデーションを追加しましたが、エラー文言の出し方がわかりませんでした。
（新規質問投稿のように、saveに失敗した際にrender 'new'みたいに書けないので、どうやってエラーを遷移先ページに引き継げばよいのかわかりませんでした。）
