### PR TITLE
create question form partial view and add tag update

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -26,6 +26,11 @@ class QuestionsController < ApplicationController
   end
 
   def update
+    @question.tags.destroy_all
+    input_tags_names.each do |name|
+      tag = Tag.register!(name)
+      @question.taggings.build(tag_id: tag.id)
+    end
     if @question.update(question_params)
       redirect_to questions_path, notice: '質問を更新しました'
     else

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,2 +1,9 @@
 module TagsHelper
+  def comma_join(tags)
+    result = []
+    tags.each do |tag|
+      result << tag[:name]
+    end
+    result.join(",")
+  end
 end

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,0 +1,11 @@
+<%= simple_form_for(question) do |f| %>
+  <%= f.label :title %>
+  <%= f.text_field :title, placeholder: "プログラミングに関する質問は何ですか？", class: 'form-control' %>
+  <br />
+  <%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+  <hr>
+  <%= f.label :tags %>
+  <%= f.text_field :tags, 'data-role'=>'tagsinput', value: comma_join(question.tags), placeholder: "質問に関連するタグをつけることができます" %>
+  <br>
+  <%= f.submit "質問を#{submit_type}する", class: "btn btn-info" %>
+<% end %>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -1,14 +1,5 @@
-<h1>質問を編集する</h1>
+<h1>質問編集</h1>
 
-<%= form_for @question do |f| %>
-  <div class="field">
-    <%= f.label :title %><br />
-    <%= f.text_field :title, autofocus: true %>
-  </div>
-  <div class="field">
-    <%= f.label :content %><br />
-    <%= f.text_area :content, autofocus: true %>
-  </div>
-  <%= f.submit %>
-<% end %>
+<%= render "questions/form", question: @question, submit_type: "更新" %>
+<br>
 <%= link_to "戻る", :back %>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,11 +1,5 @@
-<%= simple_form_for(@question) do |f| %>
-  <%= f.label :title %>
-  <%= f.text_field :title, placeholder: "プログラミングに関する質問は何ですか？", class: 'form-control' %>
-  <br />
-  <%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10 } %>
-  <hr>
-  <%= f.label :tags %>
-  <%= f.text_field :tags, 'data-role'=>'tagsinput', value: @question.tags.join(','), placeholder: "質問に関連するタグをつけることができます" %>
-  <br>
-  <%= f.submit '質問を投稿する', class: "btn btn-info" %>
-<% end %>
+<h1>新規質問</h1>
+
+<%= render "questions/form", question: @question, submit_type: "投稿" %>
+<br>
+<%= link_to "戻る", :back %>


### PR DESCRIPTION
質問フォームを共通化しました。

また、tagの更新機能がなかったので追加しました。

その他、tagの更新の際のinput formに登録済みのtagが記入されている状態にするため、

```
<%= f.text_field :tags, 'data-role'=>'tagsinput', value: comma_join(question.tags), placeholder: "質問に関連するタグをつけることができます" %>
```

のようにcommaでjoinさせるためのhelperを作りました。