### PR TITLE
Issues/#47　質問、回答入力のバリデーション追加とエラー表示追加、全画面へのnoticeメッセージエリア追加

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css
@@ -5,3 +5,17 @@
   To use Glyphicons sprites instead of Font Awesome, replace with "require twitter-bootstrap-static/sprites"
   =require twitter-bootstrap-static/fontawesome
   */
+
+/*railsの対応のnotice,alertの名称に対応するため、クラスを作成 */
+/*もとはalert-success */
+.alert-notice{
+  background-color: #dff0d8;
+  border-color: #d0e9c6;
+  color: #3c763d;
+}
+/*もとはalert-success */
+.alert-alert{
+  background-color: #f2dede;
+  border-color: #ebcccc;
+  color: #a94442;
+}

--- a/app/assets/stylesheets/simple_form.scss
+++ b/app/assets/stylesheets/simple_form.scss
@@ -5,4 +5,9 @@
     color:#a94442;
     display: block;
   }
+  .answer_content{//回答フォームのラベルは大きく
+    label{
+      font-size: 24px;
+    }
+  }
 }

--- a/app/assets/stylesheets/simple_form.scss
+++ b/app/assets/stylesheets/simple_form.scss
@@ -1,0 +1,8 @@
+// Style for simple_form
+
+.simple_form{
+  .error{
+    color:#a94442;
+    display: block;
+  }
+}

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -7,9 +7,16 @@ class AnswersController < ApplicationController
   def create
     @answer = current_user.answers.build(answer_params)
     @question = @answer.question
-    @answer.save
-    redirect_to question_path(@question)
-    NoticeMailer.sendmail_answer(@answer).deliver
+    respond_to do |format|
+      if @answer.save
+        flash[:notice] = '回答を投稿しました'
+        format.html { redirect_to question_path(@question) }
+        format.js { render js: "window.location = '#{question_path(@question)}'" }
+        NoticeMailer.sendmail_answer(@answer).deliver
+      else
+        format.js { render :error }
+      end
+    end
   end
 
   def edit

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -17,9 +17,12 @@ class QuestionsController < ApplicationController
       tag = Tag.register!(name)
       @question.taggings.build(tag_id: tag.id)
     end
-    @question.save
-    redirect_to questions_path
-    NoticeMailer.sendmail_question(@question).deliver
+    if @question.save
+      redirect_to questions_path, notice:"質問を投稿しました"
+      NoticeMailer.sendmail_question(@question).deliver
+    else
+      render "new"
+    end
   end
 
   def edit

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,7 +2,8 @@ class Answer < ActiveRecord::Base
   belongs_to :user
   belongs_to :question
   has_many :votes, dependent: :destroy
-
+   #バリデーション
+  validates :content, presence: true
   def voted_point
     self.votes.sum(:plus_or_minus)
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,7 +5,9 @@ class Question < ActiveRecord::Base
   has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
   has_many :votes, dependent: :destroy
-
+  #バリデーション
+  validates :title, presence: true
+  validates :content, presence: true
   def favorite_by(user)
     favorites.find_by(user_id: user.id)
   end

--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -1,10 +1,10 @@
 <div class="row">
   <div class="col-md-12 col-sm-12">
-    <%= simple_form_for([question,answer]) do |f| %>
+    <div id="js_answer_error_all"></div>
+    <%= simple_form_for([question,answer], remote: true) do |f| %>
       <%= f.hidden_field :question_id %>
-      <h3>
-        <%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10 },label: "回答を入力" %>
-      </h3>
+      <div><%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10},label: "回答を入力" %>
+      </div>
       <div>
         <%= f.submit '回答する' %>
       </div>

--- a/app/views/answers/error.js.erb
+++ b/app/views/answers/error.js.erb
@@ -1,0 +1,1 @@
+$("#js_answer_error_all").html("<%= j(render 'application/display_form_error', { form_error: @answer }) %>")

--- a/app/views/application/_display_flash_message.html.erb
+++ b/app/views/application/_display_flash_message.html.erb
@@ -1,0 +1,7 @@
+<% if flash %>
+  <% flash.each do |name, message| %>
+    <div class="alert alert-<%= name %>">
+      <p><%= message %></p>
+    </div>
+  <% end -%>
+<% end %>

--- a/app/views/application/_display_form_error.html.erb
+++ b/app/views/application/_display_form_error.html.erb
@@ -1,9 +1,7 @@
 <% if form_error.errors.any? %>
   <div class="alert alert-danger">
-    <ul>
-      <% form_error.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+    <% form_error.errors.full_messages.each do |message| %>
+      <p><%= message %></p>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/application/_display_form_error.html.erb
+++ b/app/views/application/_display_form_error.html.erb
@@ -1,0 +1,9 @@
+<% if form_error.errors.any? %>
+  <div class="alert alert-danger">
+    <ul>
+      <% form_error.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/application/_display_simple_form_error.html.erb
+++ b/app/views/application/_display_simple_form_error.html.erb
@@ -1,0 +1,5 @@
+<% if form_error %>
+  <div class="alert alert-danger">
+    <div><%= form_error %></div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
   </header>
 
   <div class="yield container">
+    <%= render partial: 'application/display_flash_message', flash: flash %>
     <%= yield %>
   <!-- /.container --></div>
 

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for(question) do |f| %>
-  <%= f.label :title %>
-  <%= f.text_field :title, placeholder: "プログラミングに関する質問は何ですか？", class: 'form-control' %>
+  <%= render 'application/display_simple_form_error', form_error: f.error_notification %>
+  <%= f.input :title, placeholder: "プログラミングに関する質問は何ですか？", input_html: {class: 'form-control'} %>
   <br />
   <%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10 } %>
   <hr>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -46,13 +46,13 @@ SimpleForm.setup do |config|
     ## Inputs
     b.use :label_input
     b.use :hint,  wrap_with: { tag: :span, class: :hint }
-    b.use :error, wrap_with: { tag: :span, class: :error }
+    #b.use :error, wrap_with: { tag: :span, class: :error }
 
     ## full_messages_for
     # If you want to display the full error message for the attribute, you can
     # use the component :full_error, like:
     #
-    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+    b.use :full_error, wrap_with: { tag: :span, class: :error }
   end
 
   # The default wrapper to be used by the FormBuilder.


### PR DESCRIPTION
#46
#47 

プルリクしていた#46_testブランチの改訂版です。コンフリクトしていたため新しくブランチ切りました。（#46_testはあとでクローズします）

＜やったこと＞
・質問、回答フォームの必須項目未入力時にエラーメッセージを出す（質問編集は確認できてませんでした！別issueたてます）
・質問、回答のsave時の成功時に、●●できましたのようなメッセージを出す

simple_formのエラー表示（入力inputの下にエラーメッセージが出る）にできるだけそろえようと思いますが、
回答フォームの部分はajaxでうまくsimple_formエラーを呼べなかったので（いったんは表示できたんですがマークダウンのプレビューがきかなくなってしまったので、）
質問フォームとは違うエラー表示をしてます。

＜別issueでやります＞
・ユーザー、ログインまわりバリデーション、エラーメッセージ
・質問のupdate周りを確認してなかったので、エラーメッセージ出るか確認します
・simple_formのエラーメッセージの一部が英語なので修正する
