### PR TITLE
Issues/#108　ログイン、サインアップ画面の表示修正・エラー表示修正、ユーザー一覧の表示修正

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -15,3 +15,36 @@
   max-height:48px;
   overflow: hidden;
 }
+
+//ユーザー一覧用リストスタイル
+.userlist-style-original{
+  display: -webkit-flex;
+  display:flex;
+  -webkit-flex-wrap:wrap;
+  flex-wrap:wrap;
+}
+
+.user-style-child-original{
+  @media (max-width: 767px){
+    width:100%;
+  }
+}
+
+//ユーザー一覧用リスト リンクスタイル
+.userlink-style-original{
+  padding: 15px;
+  display: block;
+  border-radius:4px;
+  transition-property:background-color;
+  transition-duration:0.5s;
+  transition-timing-function:ease;
+  &:hover{
+    background-color:#eeeeee;
+  }
+  .lead{
+    margin-bottom: 0;//bootstrap上書き
+    & + p{
+      margin-top: 12px;
+    }
+  }
+}

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -8,12 +8,14 @@
   max-width:164px;
   max-height:164px;
   overflow: hidden;
+  vertical-align: top;
 }
 .img-profile-wrap-small-original{
   display:inline-block;
   max-width:48px;
   max-height:48px;
   overflow: hidden;
+  vertical-align: top;
 }
 
 //ユーザー一覧用リストスタイル
@@ -25,6 +27,7 @@
 }
 
 .user-style-child-original{
+  padding:15px;
   @media (max-width: 767px){
     width:100%;
   }
@@ -33,8 +36,10 @@
 //ユーザー一覧用リスト リンクスタイル
 .userlink-style-original{
   padding: 15px;
-  display: block;
+  display: table;
+  width: 100%;
   border-radius:4px;
+  border:1px solid #eeeeee;
   transition-property:background-color;
   transition-duration:0.5s;
   transition-timing-function:ease;
@@ -46,5 +51,17 @@
     & + p{
       margin-top: 12px;
     }
+    @media (max-width: 767px){
+      font-size:20px;
+    }
+  }
+  .col-left-original{
+    display:table-cell;
+    width:54px;
+    vertical-align:middle;
+  }
+  .col-right-original{
+    display:table-cell;
+    vertical-align:middle;
   }
 }

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,12 +3,12 @@
     <div class="panel panel-style-01-original">
       <h1>プロフィールを編集</h1>
       <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-        <%= render 'application/display_form_error', form_error: resource %>
+        <%= render 'application/display_simple_form_error', form_error: f.error_notification %>
         <div class="form-group">
           <%= f.input :name,  input_html: { class: "form-control"}, placeholder: "名前" %>
         </div>
         <div class="form-group">
-          <%= f.input :email, autofocus: true, input_html: { class: "form-control"}, placeholder: "メールアドレス" %>
+          <%= f.input :email, autofocus: false, input_html: { class: "form-control"}, placeholder: "メールアドレス" %>
         </div>
 
         <hr>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,3 @@
-<%= render 'application/display_form_error', form_error: resource %>
 <div class="row align-items-center">
   <div class="col-sm-4 col-sm-offset-4">
 
@@ -6,6 +5,7 @@
       <h1 class="text-center">サインアップ</h1>
 
       <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render 'application/display_simple_form_error', form_error: f.error_notification %>
         <div class="form-group">
           <%= f.input :email, autofocus: true, placeholder: "メールアドレス", input_html: { class: "form-control"}, label: false %>
         </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,38 @@
-<h2>Sign up</h2>
+<%= render 'application/display_form_error', form_error: resource %>
+<div class="row align-items-center">
+  <div class="col-sm-4 col-sm-offset-4">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+    <div class="panel panel-style-01-original">
+      <h1 class="text-center">サインアップ</h1>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <div class="form-group">
+          <%= f.input :email, autofocus: true, placeholder: "メールアドレス", input_html: { class: "form-control"}, label: false %>
+        </div>
+
+        <div class="form-group">
+          <%= f.input :name, autofocus: true, placeholder: "名前", input_html: { class: "form-control"}, label: false %>
+        </div>
+
+        <div class="form-group">
+          <%= f.input :password, autocomplete: "off", placeholder: "パスワード", input_html: { class: "form-control"}, label: false %>
+          <% if @minimum_password_length %>
+            <small class="form-text text-muted"><%= @minimum_password_length %> 文字以上で入力してください。</small>
+          <% end %>
+        </div>
+
+        <div class="form-group">
+          <%= f.input :password_confirmation, placeholder: "確認用パスワード", autocomplete: "off", input_html: { class: "form-control"}, label: false %>
+        </div>
+
+        <p class="text-center">
+          <%= f.submit "サインアップ", class: "btn btn-primary btn-block" %>
+        </p>
+      <% end %>
+    <!-- /.panel-style-01-original--></div>
+
+    <%= render "devise/shared/links" %>
   </div>
+</div>
 
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
       <h1 class="text-center">ログイン</h1>
 
       <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-        <%= render 'application/display_form_error', form_error: resource %>
+        <%= render 'application/display_simple_form_error', form_error: f.error_notification %>
         <div class="form-group">
           <%= f.input :email, autofocus: true, placeholder: "メールアドレス", input_html: { class: "form-control"}, label: false %>
         </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,32 @@
-<h2>Log in</h2>
+<div class="row">
+  <div class="col-sm-4 col-sm-offset-4">
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <div class="panel panel-style-01-original">
+      <h1 class="text-center">ログイン</h1>
+
+      <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <%= render 'application/display_form_error', form_error: resource %>
+        <div class="form-group">
+          <%= f.input :email, autofocus: true, placeholder: "メールアドレス", input_html: { class: "form-control"}, label: false %>
+        </div>
+
+        <div class="form-group">
+          <%= f.input :password, autocomplete: "off", placeholder: "パスワード", input_html: { class: "form-control"}, label: false %>
+        </div>
+
+        <% if devise_mapping.rememberable? -%>
+          <div class="form-group">
+            <%= f.check_box :remember_me %>
+            <%= f.label :remember_me %>
+          </div>
+        <% end -%>
+
+        <p class="text-center">
+          <%= f.submit "ログイン", class: "btn btn-primary btn-block" %>
+        </p>
+      <% end %>
+    <!-- /.panel-style-01-original--></div>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end -%>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,27 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+<div class="text-center">
+  <%- if controller_name != 'sessions' %>
+    <p><%= link_to "ログイン", new_session_path(resource_name) %></p>
   <% end -%>
-<% end -%>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <p><%= link_to "サインアップ", new_registration_path(resource_name) %></p>
+  <% end -%>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <p><%= link_to "パスワードをお忘れですか？", new_password_path(resource_name) %></p>
+  <% end -%>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <p><%= link_to "確認メールを受け取ることができない場合", new_confirmation_path(resource_name) %></p>
+  <% end -%>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <p><%= link_to "解除用メールを受け取ることができない場合", new_unlock_path(resource_name) %></p>
+  <% end -%>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <p><%= link_to "#{OmniAuth::Utils.camelize(provider)}でログイン", omniauth_authorize_path(resource_name, provider) %></p>
+    <% end -%>
+  <% end -%>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,10 +1,17 @@
 <h1>ユーザー一覧</h1>
 
+<div class="userlist-style-original row">
 <% @users.each do |user| %>
-  <div class="user_info">
-    <h2><%= link_to user.name, user_path(user) %></h2>
-    <p>profile: <%= user.profile %></p>
-    <p>avatar: <%= user.avatar %></p>
-    <p>vote: </p>
+  <div class="user-style-child-original col-sm-3">
+    <%= link_to user_path(user),class:"row userlink-style-original" do %>
+        <div class="col-xs-3 row">
+          <span class="img-profile-wrap-small-original"><%= profile_img(user) %></span>
+        </div>
+        <div class="col-xs-9">
+            <p class="lead"><%= user.name %></p>
+        </div>
+    <% end %>
   </div>
 <% end %>
+
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,11 +3,11 @@
 <div class="userlist-style-original row">
 <% @users.each do |user| %>
   <div class="user-style-child-original col-sm-3">
-    <%= link_to user_path(user),class:"row userlink-style-original" do %>
-        <div class="col-xs-3 row">
+    <%= link_to user_path(user),class:"userlink-style-original" do %>
+        <div class="col-left-original row">
           <span class="img-profile-wrap-small-original"><%= profile_img(user) %></span>
         </div>
-        <div class="col-xs-9">
+        <div class="col-right-original">
             <p class="lead"><%= user.name %></p>
         </div>
     <% end %>

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -1,0 +1,24 @@
+ja:
+  simple_form:
+    "yes": 'はい'
+    "no": 'いいえ'
+    required:
+      text: 'required'
+      mark: '*'
+      message: '印のついている項目は入力が必須です。'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "エラーがあります。確認してください。"
+    # Labels and hints examples
+    # labels:
+    #   password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail para efetuar o sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   username: 'User name to sign in.'
+    #   password: 'No special characters, please.'


### PR DESCRIPTION
#108 
やったこと
- ログイン、サインアップ画面の表示修正(simple_formに変更)
- ログイン、サインアップ画面のエラー表示をbootstrapに修正
- ユーザー一覧の表示修正　※何を出すべきか悩んだのでアバター画像と名前以外はいったん消しました。。

ログインとサインアップ画面のエラーの出どころが下記のようにちがっていて、
すぐに解決できなさそうだったので表示だけなんとなく同じになるようにごまかしています・・。
- ログイン ー＞ フラッシュメッセージ（application/_display_flash_message.html.erb　を使用）
- サインアップ ー＞ simple_formの各エラーとフラッシュメッセージ（application/_display_form_error.html.erb　を使用）
