### PR TITLE
Fix display of devise pages 　devise関連ページの表示修正、ボタンの色をinfoに変更

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,21 @@
-<h2>Resend confirmation instructions</h2>
+<div class="row align-items-center">
+  <div class="col-sm-4 col-sm-offset-4">
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+    <div class="panel panel-style-01-original">
+      <h1 class="text-center">確認メール送信</h1>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+      <%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+        <%= render 'application/display_simple_form_error', form_error: f.error_notification %>
+        <div class="form-group">
+          <%= f.input :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: "メールアドレス", input_html: { class: "form-control"},label:false %>
+        </div>
+
+        <p class="text-center">
+          <%= f.submit "確認メール送信", class: "btn btn-info" %>
+        </p>
+      <% end %>
+
+    <!-- /.panel-style-01-original--></div>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,28 @@
-<h2>Change your password</h2>
+<div class="row align-items-center">
+  <div class="col-sm-4 col-sm-offset-4">
+    <div class="panel panel-style-01-original">
+      <h1 class="text-center">パスワード変更</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
-  <%= f.hidden_field :reset_password_token %>
+      <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render 'application/display_simple_form_error', form_error: f.error_notification %>
+        <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+        <div class="form-group">
+          <%= f.input :password, autofocus: true, autocomplete: "off", placeholder: "新しいパスワード", input_html: { class: "form-control"},label:false %>
+          <% if @minimum_password_length %>
+            <small class="form-text text-muted"><%= @minimum_password_length %> 文字以上で入力してください。</small>
+          <% end %>
+        </div>
+
+        <div class="form-group">
+          <%= f.input :password_confirmation, autocomplete: "off", placeholder: "新しいパスワード確認", input_html: { class: "form-control"},label:false %>
+        </div>
+        <p class="text-center">
+          <%= f.submit "パスワード変更", class: "btn btn-info" %>
+        </p>
+      <% end %>
+
+    <!-- /.panel-style-01-original--></div>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,18 @@
-<h2>Forgot your password?</h2>
+<div class="row align-items-center">
+  <div class="col-sm-4 col-sm-offset-4">
+    <div class="panel panel-style-01-original">
+      <h1 class="text-center">パスワードリセット</h1>
+      <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+        <%= render 'application/display_simple_form_error', form_error: f.error_notification %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+        <div class="form-group">
+          <%= f.input :email, autofocus: true, placeholder: "メールアドレス", input_html: { class: "form-control"},label:false %>
+        </div>
+        <p class="text-center">
+          <%= f.submit "パスワードリセットメール送信", class: "btn btn-info" %>
+        </p>
+      <% end %>
+    <!-- /.panel-style-01-original--></div>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -26,7 +26,7 @@
         </div>
 
         <p class="text-center">
-          <%= f.submit "サインアップ", class: "btn btn-primary btn-block" %>
+          <%= f.submit "サインアップ", class: "btn btn-info btn-block" %>
         </p>
       <% end %>
     <!-- /.panel-style-01-original--></div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -22,7 +22,7 @@
         <% end -%>
 
         <p class="text-center">
-          <%= f.submit "ログイン", class: "btn btn-primary btn-block" %>
+          <%= f.submit "ログイン", class: "btn btn-info btn-block" %>
         </p>
       <% end %>
     <!-- /.panel-style-01-original--></div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,16 +1,21 @@
-<h2>Resend unlock instructions</h2>
+<div class="row align-items-center">
+  <div class="col-sm-4 col-sm-offset-4">
+    <div class="panel panel-style-01-original">
+      <h1 class="text-center">ロック解除メール送信</h1>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+      <%= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+        <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+        <div class="form-group">
+          <%= f.input :email, autofocus: true, placeholder: "メールアドレス", input_html: { class: "form-control"},label:false %>
+        </div>
+
+        <p class="text-center">
+          <%= f.submit "ロック解除メール送信", class: "btn btn-info" %>
+        </p>
+      <% end %>
+
+    <!-- /.panel-style-01-original--></div>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>


### PR DESCRIPTION
#170 
#150 
- devise関連ページの表示修正
　- パスワードリセットメール送信画面・パスワード変更画面
　- 確認メール送信画面(届かない場合)
　- ロック解除メール送信画面
- 各ページのボタンのクラスをbtn-infoに変更